### PR TITLE
Renamed borgbackup-llfuse formula

### DIFF
--- a/Formula/borgbackup-fuse.rb
+++ b/Formula/borgbackup-fuse.rb
@@ -19,11 +19,11 @@ class OsxfuseRequirement < Requirement
   end
 
   def message
-    "osxfuse is required to build borgbackup-llfuse. Please run `brew install --cask osxfuse` first."
+    "osxfuse is required to build borgbackup-fuse. Please run `brew install --cask osxfuse` first."
   end
 end
 
-class BorgbackupLlfuse < Formula
+class BorgbackupFuse < Formula
   include Language::Python::Virtualenv
 
   desc "Deduplicating archiver with compression and authenticated encryption"
@@ -37,7 +37,7 @@ class BorgbackupLlfuse < Formula
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 
-  conflicts_with "borgbackup", because: "borgbackup-llfuse is a patched version of borgbackup"
+  conflicts_with "borgbackup", because: "borgbackup-fuse is a patched version of borgbackup"
 
   depends_on OsxfuseRequirement => :build
   depends_on "pkg-config" => :build

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Why install [Borg](https://www.borgbackup.org/) using this tap vs `brew install borgbackup`?
 
-The `borgbackup-llfuse` formula maintained in this tap depends on [osxfuse](https://formulae.brew.sh/cask/osxfuse) (aka FUSE for macOS) and [llfuse](https://github.com/python-llfuse/python-llfuse/) which are required to mount repositories or archives using `borg mount`.
+The `borgbackup-fuse` formula maintained in this tap depends on [osxfuse](https://formulae.brew.sh/cask/osxfuse) (aka FUSE for macOS) and [llfuse](https://github.com/python-llfuse/python-llfuse/) which are required to mount repositories or archives using `borg mount`.
 
 These dependencies have been [removed](https://github.com/Homebrew/homebrew-core/commit/8c2f17e3b653347ada86d353243e2d6b6cb10fda#diff-4a25217474a5eb61d0776ab4cabc43b42689bc7b3efaaed400f799631dcec71f) from Homebrew’s [borgbackup](https://formulae.brew.sh/formula/borgbackup) formula because [FUSE for macOS](https://osxfuse.github.io/) is no longer open source.
 
@@ -12,7 +12,7 @@ If one doesn’t plan on using `borg mount`, installing Borg using `brew install
 
 ```shell
 brew install --cask osxfuse
-brew install borgbackup/tap/borgbackup-llfuse
+brew install borgbackup/tap/borgbackup-fuse
 ```
 
 ## Documentation


### PR DESCRIPTION
Renamed formula to `borgbackup-fuse` as discussed [here](https://github.com/borgbackup/homebrew-tap/pull/1) given `llfuse` has been deprecated and we will likely switch to `pyfuse3` shortly.