### PR TITLE
 Bump to Borg 1.2.2

### DIFF
--- a/Formula/borgbackup-fuse.rb
+++ b/Formula/borgbackup-fuse.rb
@@ -12,7 +12,7 @@ class OsxfuseRequirement < Requirement
 
   env do
     ENV.append_path "PKG_CONFIG_PATH",
-                    "/usr/local/lib/pkgconfig:#{HOMEBREW_PREFIX}/lib/pkgconfig:"\
+                    "/usr/local/lib/pkgconfig:#{HOMEBREW_PREFIX}/lib/pkgconfig:" \
                     "#{HOMEBREW_PREFIX}/opt/openssl@1.1/lib/pkgconfig"
     ENV.append_path "BORG_OPENSSL_PREFIX", "#{HOMEBREW_PREFIX}/opt/openssl@1.1/"
 

--- a/Formula/borgbackup-fuse.rb
+++ b/Formula/borgbackup-fuse.rb
@@ -32,8 +32,8 @@ class BorgbackupFuse < Formula
 
   desc "Deduplicating archiver with compression and authenticated encryption"
   homepage "https://borgbackup.org/"
-  url "https://files.pythonhosted.org/packages/e5/7e/3098f7ba4e5b6caec1657cd44e3c5d309fad83ba7bb6f6b8433315a5adbc/borgbackup-1.2.1.tar.gz"
-  sha256 "9f9ce2d1923cb33a147ee6d08177d860974567721b1142fca67914a02e64c633"
+  url "https://files.pythonhosted.org/packages/a2/98/479f364b69182b9a29c82607a17a9cf2e3cdc8743bb9570a4da9d511d0a6/borgbackup-1.2.2.tar.gz"
+  sha256 "d730687443f1beb602b1d72bae36318f6f9654818fcdc50458540ec579e57260"
   license "BSD-3-Clause"
 
   livecheck do


### PR DESCRIPTION
Update Borgbackup to version 1.2.2, no other changes required for the formula to work.