### PR TITLE
Fix borgbackup unable to find packaging dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Test formula
         run: |
-          brew style --cask borgbackup-fuse
-          brew audit --cask --online --strict borgbackup-fuse
+          brew style borgbackup-fuse
+          brew audit --online --strict borgbackup-fuse
 
           brew install borgbackup-fuse
           brew test borgbackup-fuse

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Install macFUSE
         run: brew install --cask macfuse
@@ -31,4 +31,3 @@ jobs:
           # mkdir mnt
           # borg mount test-repo::test-archive mnt
           # ls mnt/Formula
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
           brew uninstall borgbackup-fuse
 
       # Step is disabled because it times out on GH hosted runners
-      # bacause of a macOS security promt - can only be done on
+      # bacause of a macOS security prompt - can only be done on
       # selfhosted runners
       - name: Test mount command
         if: vars.TESTMOUNT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 on:
-  pull_request:
+  # Allow manually triggering this workflow
+  workflow_dispatch:
+  # run for all pull requests and pushes to certain branches
   push:
+    branches:
+      - master
 
 jobs:
   test:
@@ -42,7 +46,7 @@ jobs:
           HOMEBREW_NO_INSTALL_FROM_API: 1
         run: |
           brew install borgbackup-fuse
-          
+
           brew test borgbackup-fuse
           brew style borgbackup-fuse
           brew audit --online --strict borgbackup-fuse

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,8 @@ jobs:
         run: brew install --cask macfuse
 
       - name: Test formula
+        env:
+          HOMEBREW_NO_INSTALL_FROM_API: 1
         run: |
           brew install borgbackup-fuse
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,10 @@ jobs:
 
       - name: Test formula
         run: |
+          brew install borgbackup-fuse
+          
+          brew test borgbackup-fuse
           brew style borgbackup-fuse
           brew audit --online --strict borgbackup-fuse
 
-          brew install borgbackup-fuse
-          brew test borgbackup-fuse
           brew uninstall borgbackup-fuse

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ on:
   # Allow manually triggering this workflow
   workflow_dispatch:
   # run for all pull requests and pushes to certain branches
+  pull_request:
   push:
     branches:
       - master
@@ -52,3 +53,16 @@ jobs:
           brew audit --online --strict borgbackup-fuse
 
           brew uninstall borgbackup-fuse
+
+      # Step is disabled because it times out on GH hosted runners
+      # bacause of a macOS security promt - can only be done on
+      # selfhosted runners
+      - name: Test mount command
+        if: vars.TESTMOUNT
+        run: |
+          borg init -e none test-repo
+          borg create test-repo::test-archive Formula
+          
+          mkdir mnt
+          borg mount test-repo::test-archive mnt
+          ls mnt/Formula

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,33 +1,47 @@
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
 
 jobs:
   test:
     name: Test Homebrew install
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - macos-13
+          - macos-14
     timeout-minutes: 15
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          test-bot: false
+
+      - name: Cache Homebrew Gems
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ matrix.os }}-rubygems-
+
+      - name: Install Homebrew Gems
+        id: gems
+        run: brew install-bundler-gems
+        if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Install macFUSE
         run: brew install --cask macfuse
 
-      # - name: Debug
-      #   uses: mxschmitt/action-tmate@v3
-
       - name: Test formula
-        working-directory: ./Formula
         run: |
-          # brew audit --strict borgbackup-fuse.rb
-          brew install borgbackup-fuse.rb
-          brew test borgbackup-fuse.rb
+          brew style --cask borgbackup-fuse
+          brew audit --cask --online --strict borgbackup-fuse
 
-      - name: Test mount command
-        run: |
-          borg init -e none test-repo
-          borg create test-repo::test-archive Formula
-          # Will timeout due to macOS security prompt
-          # mkdir mnt
-          # borg mount test-repo::test-archive mnt
-          # ls mnt/Formula
+          brew install borgbackup-fuse
+          brew test borgbackup-fuse
+          brew uninstall borgbackup-fuse

--- a/Formula/borgbackup-fuse.rb
+++ b/Formula/borgbackup-fuse.rb
@@ -46,26 +46,30 @@ class BorgbackupFuse < Formula
   depends_on "libb2"
   depends_on "lz4"
   depends_on "openssl@3"
-  depends_on "python-packaging"
-  depends_on "python@3.11"
+  depends_on "python@3.13"
   depends_on "xxhash"
   depends_on "zstd"
 
   conflicts_with "borgbackup", because: "borgbackup-fuse is a patched version of borgbackup"
 
   resource "msgpack" do
-    url "https://files.pythonhosted.org/packages/08/4c/17adf86a8fbb02c144c7569dc4919483c01a2ac270307e2d59e1ce394087/msgpack-1.0.8.tar.gz"
-    sha256 "95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"
+    url "https://files.pythonhosted.org/packages/cb/d0/7555686ae7ff5731205df1012ede15dd9d927f6227ea151e901c7406af4f/msgpack-1.1.0.tar.gz"
+    sha256 "dd432ccc2c72b914e4cb77afce64aab761c1137cc698be3984eee260bcb2896e"
+  end
+
+  resource "packaging" do
+    url "https://files.pythonhosted.org/packages/51/65/50db4dda066951078f0a96cf12f4b9ada6e4b811516bf0262c0f4f7064d4/packaging-24.1.tar.gz"
+    sha256 "026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"
   end
 
   resource "pyparsing" do
-    url "https://files.pythonhosted.org/packages/46/3a/31fd28064d016a2182584d579e033ec95b809d8e220e74c4af6f0f2e8842/pyparsing-3.1.2.tar.gz"
-    sha256 "a1bac0ce561155ecc3ed78ca94d3c9378656ad4c94c1270de543f621420f94ad"
+    url "https://files.pythonhosted.org/packages/8c/d5/e5aeee5387091148a19e1145f63606619cb5f20b83fccb63efae6474e7b2/pyparsing-3.2.0.tar.gz"
+    sha256 "cbf74e27246d595d9a74b186b810f6fbb86726dbf3b9532efb343f6d7294fe9c"
   end
 
   resource "llfuse" do
-    url "https://files.pythonhosted.org/packages/d2/2c/64f01042d1ed08725342c85ddb48a29d2a4f8712d27f22f66f28a67a079c/llfuse-1.5.0.tar.gz"
-    sha256 "d094448bb4eb20099537be53dc2b5b2c0369d36bde09207a9bb228cc3cd58ee1"
+    url "https://files.pythonhosted.org/packages/be/a5/a3dc8426732f75ff2cdd48aaaa60a44afd56812760f49198c0d204768b1f/llfuse-1.5.1.tar.gz"
+    sha256 "7c9be52289cf647e3d735104531cc23a1a89fd1be3a621613a1cc0991f1b2699"
   end
 
   def install
@@ -74,6 +78,7 @@ class BorgbackupFuse < Formula
     ENV["BORG_LIBXXHASH_PREFIX"] = Formula["xxhash"].prefix
     ENV["BORG_LIBZSTD_PREFIX"] = Formula["zstd"].prefix
     ENV["BORG_OPENSSL_PREFIX"] = Formula["openssl@3"].prefix
+
     virtualenv_install_with_resources
 
     man1.install Dir["docs/man/*.1"]

--- a/Formula/borgbackup-fuse.rb
+++ b/Formula/borgbackup-fuse.rb
@@ -62,11 +62,6 @@ class BorgbackupFuse < Formula
     sha256 "026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"
   end
 
-  resource "pyparsing" do
-    url "https://files.pythonhosted.org/packages/8c/d5/e5aeee5387091148a19e1145f63606619cb5f20b83fccb63efae6474e7b2/pyparsing-3.2.0.tar.gz"
-    sha256 "cbf74e27246d595d9a74b186b810f6fbb86726dbf3b9532efb343f6d7294fe9c"
-  end
-
   resource "llfuse" do
     url "https://files.pythonhosted.org/packages/be/a5/a3dc8426732f75ff2cdd48aaaa60a44afd56812760f49198c0d204768b1f/llfuse-1.5.1.tar.gz"
     sha256 "7c9be52289cf647e3d735104531cc23a1a89fd1be3a621613a1cc0991f1b2699"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ These dependencies have been [removed](https://github.com/Homebrew/homebrew-core
 
 If one doesn’t plan on using `borg mount`, installing Borg using `brew install borgbackup` works just fine.
 
-
 ## How to install Borg using this tap?
 
 ```shell
@@ -16,14 +15,12 @@ brew install --cask macfuse
 brew install borgbackup/tap/borgbackup-fuse
 ```
 
-
 ## How to update to a new BorgBackup version?
 
 1. Get new package URLs and SHAs from [PyPi](https://pypi.org/project/borgbackup/)
 2. ~~Lint `brew audit --strict Formula/borgbackup-fuse.rb`~~
 3. Install `brew install Formula/borgbackup-fuse.rb`
 4. Test `brew test Formula/borgbackup-fuse.rb`
-
 
 ## Documentation
 


### PR DESCRIPTION
Closes #36, #38 and #27

I updated the formula with the changes from the official homebrew repository adding the missing `packaging` dependency. Additionally I updated the CI workflow to test that the formula can be installed, uninstalled and used to create a backup via the formulas `test` method.